### PR TITLE
Gold plating the 2.13.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Silencer: Scala compiler plugin for warning suppression
 
 [![Build Status](https://travis-ci.org/ghik/silencer.svg?branch=master)](https://travis-ci.org/ghik/silencer)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.ghik/silencer-plugin_2.13.0/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.ghik/silencer-plugin_2.13.0)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.ghik/silencer-plugin_2.13.1/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.ghik/silencer-plugin_2.13.1)
 
 Scala has no local warning suppression (see e.g. [scala/bug/issues/1781](https://github.com/scala/bug/issues/1781) 
 for discussion). This plugin aims to change the situation. The direct motivation for this plugin is to be able to 
@@ -23,7 +23,7 @@ If you're using Gradle:
 
 ```groovy
 ext {
-    scalaVersion = "..." // e.g. "2.13.0"
+    scalaVersion = "..." // e.g. "2.13.1"
     silencerVersion = "..." // appropriate silencer version
 }
 configurations {

--- a/build.sbt
+++ b/build.sbt
@@ -85,10 +85,7 @@ lazy val `silencer-plugin` = project.dependsOn(`silencer-lib`)
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      if (scalaBinaryVersion.value == "2.13")
-        "org.scalatest" %% "scalatest" % "3.1.0-SNAP13" % Test
-      else
-        "org.scalatest" %% "scalatest" % "3.0.8-RC5" % Test
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
     ),
     saveTestClasspath := {
       val result = (classDirectory in Test).value / "embeddedcp"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.3.0-RC1
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M4")


### PR DESCRIPTION
Bump SBT to 1.3.0

Remove sbt-coursier as it's upstreamed into SBT 1.3.x

Replace RC and SNAP version of scalatest-3.x with latest stable